### PR TITLE
import 'os', 'shutil' to resolve undefined names

### DIFF
--- a/utils/train_settings.py
+++ b/utils/train_settings.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+import shutil
 
 def parse_settings():
 


### PR DESCRIPTION
In this file, there are still two undefined names: '_args_' and '_torch_'.