### PR TITLE
Fix the different behavior of the division operator in python3.6 

### DIFF
--- a/magnet_loss/magnet_tools.py
+++ b/magnet_loss/magnet_tools.py
@@ -165,4 +165,4 @@ class ClusterBatchBuilder(object):
 
     def get_class_ind(self, c):
         """Given a cluster index return the class index."""
-        return c / self.k
+        return c // self.k


### PR DESCRIPTION
get_class_ind() function is supposed to return class indices, but '/' operator does float division in python3.6 while it does integer divison in python2.7. As a result, we can get class indices such as 9.75, which creates a bug in the code. For example, we have the below line at line 171.

`sq_dists[self.get_class_ind(seed_cluster) == self.cluster_classes] = np.inf`

When the left-hand side of == does not return a whole number in python3.6, none of the values in self.cluster_classes are equal to that value. This behaviour is fixed by changing '/' to '//' since '//' does integer division in both python versions.